### PR TITLE
Fix: Crash when creating a new dynamic Single Player Profile and Allow selection of character beyond the 8 characters on screen.

### DIFF
--- a/Profile.h
+++ b/Profile.h
@@ -24,14 +24,14 @@ class Profile {
     void init(ProfileType pt, const wchar_t* _ipUsername, const wchar_t* _password, const wchar_t* _charname, const wchar_t* _gateway, const wchar_t _diff,
               unsigned int _maxLoginTime, unsigned int _maxCharTime) {
         type = pt;
-        wcscpy_s(username, wcslen(username), _ipUsername);
-        wcscpy_s(password, wcslen(password), _password);
-        wcscpy_s(gateway, wcslen(gateway), _gateway);
-        wcscpy_s(charname, wcslen(charname), _charname);
+        wcscpy_s(username, _countof(username), _ipUsername);
+		wcscpy_s(password, _countof(password), _password);
+        wcscpy_s(gateway, _countof(gateway), _gateway);
+        wcscpy_s(charname, _countof(charname), _charname);
         diff = _diff;
         maxLoginTime = _maxLoginTime;
         maxCharTime = _maxCharTime;
-    }
+	}
 
   public:
     // Get the active profile


### PR DESCRIPTION
This PR adds two fixes two D2BS issues that I hit during experimenting with it.

## First issue

The first issue is that D2BS crashes (not always, but still very often) when creating a new Dynamic profile via `Profile(1, "charname", difficulty)`. 

This manifests really well when running multiple games consecutively via D2Bot. Example code than runs in the main menu/character selection screen.

```
function getRandomInt(max) {
  return Math.floor(Math.random() * Math.floor(max));
}

while (true) {
	if (getLocation() == 8 || getLocation() == 12) {
		const newProfile = Profile(
			1,
			"borc-three",
			getRandomInt(3)
		);
		newProfile.login();
	}
}
```

D2BS will crash within the `Profile()` call as I'm guessing it's trying to allocate the wrong amount of memory during `wcscpy_s(password, wcslen(password), _password);` and some of the others. 

The fix seems to be to change `wcslen` to `_countof`. I'm not sure if it still works for Battle Net connections, as I'm only testing on Single Player and have no intention on attempting to connect to any server with this :)

## Second issue
The second issue is that D2BS is unable to select a character beyond the 8 characters on screen. The added code changes the character search/selection to make it scroll (if possible) after each scan, until it finds the character it's looking for or if it's unable to scroll further.

I haven't tested what happens with odd number of characters yet. 